### PR TITLE
build: Add Python 3.9 competible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "price-loaders"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python module that can you scrape data from Tradingview and YahooFinance"
 authors = ["prem <prem.ch@ku.th>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 requests = "^2.31.0"
 pandas = "^2.1.4"
 pytz = "^2023.3.post1"


### PR DESCRIPTION
There is  a report mentioning that the module is not compatible with Python 3.9 on Google Colab. This PR is meant to resolve this.